### PR TITLE
Build: include <thread> for C++11 and newer

### DIFF
--- a/src/entry_handler.cpp
+++ b/src/entry_handler.cpp
@@ -14,7 +14,8 @@
 *    You should have received a copy of the GNU General Public License
 *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
-
+#include <thread>
+#include <chrono>
 #include "entry_handler.h"
 #include <assert.h>
 #include <cinttypes>

--- a/tests/unit_test/t_breakpoint.cpp
+++ b/tests/unit_test/t_breakpoint.cpp
@@ -14,7 +14,8 @@
 *    You should have received a copy of the GNU General Public License
 *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
-
+#include <thread>
+#include <chrono>
 #include "catch.hpp"
 #include "zoe/zoe.h"
 #include "test_data.h"

--- a/tests/unit_test/t_cance.cpp
+++ b/tests/unit_test/t_cance.cpp
@@ -15,6 +15,8 @@
 *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
+#include <thread>
+#include <chrono>
 #include "catch.hpp"
 #include "test_data.h"
 #include "zoe/zoe.h"

--- a/tests/unit_test/t_multi_thread.cpp
+++ b/tests/unit_test/t_multi_thread.cpp
@@ -14,7 +14,8 @@
 *    You should have received a copy of the GNU General Public License
 *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
-
+#include <thread>
+#include <chrono>
 #include "catch.hpp"
 #include "zoe/zoe.h"
 #include "test_data.h"

--- a/tests/unit_test/t_uncompleted_slice_save_policy.cpp
+++ b/tests/unit_test/t_uncompleted_slice_save_policy.cpp
@@ -15,6 +15,8 @@
 *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
+#include <thread>
+#include <chrono>
 #include "catch.hpp"
 #include "zoe/zoe.h"
 #include "test_data.h"


### PR DESCRIPTION
Fixes compilation errors on GCC/Clang when building unit tests.

The file t_breakpoint.cpp (and any others using sleep_for) were missing the <thread> include. Adding this header ensures that std::this_thread::sleep_for works correctly with C++11 and newer standards (C++14, C++17, C++20).

The files include
└─$ grep -rnw . -e "sleep_for" 

./tests/unit_test/t_multi_thread.cpp:57:  std::this_thread::sleep_for(std::chrono::milliseconds(5000));
./tests/unit_test/t_multi_thread.cpp:64:  std::this_thread::sleep_for(std::chrono::milliseconds(5000));
./tests/unit_test/t_multi_thread.cpp:71:  std::this_thread::sleep_for(std::chrono::milliseconds(5000));
./tests/unit_test/t_uncompleted_slice_save_policy.cpp:50:  std::this_thread::sleep_for(std::chrono::milliseconds(100));
./tests/unit_test/t_breakpoint.cpp:47:    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
./tests/unit_test/t_cance.cpp:36:    std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
./tests/unit_test/t_cance.cpp:67:    std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
./src/entry_handler.cpp:367:      std::this_thread::sleep_for(std::chrono::milliseconds(100));
./src/entry_handler.cpp:377:        std::this_thread::sleep_for(std::chrono::milliseconds(50));


This resolves build failures and makes unit tests compile out-of-the-box.
